### PR TITLE
chore(OrderType): serialize, deserialize for OrderType + OrderRaw update

### DIFF
--- a/src/api/authenticated/orders/types.rs
+++ b/src/api/authenticated/orders/types.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::api::common::PlaceHolder;
 
@@ -13,8 +13,7 @@ pub enum OrderFlag {
     NoVarRates = 524288,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OrderType {
     Limit,
     ExchangeLimit,
@@ -32,6 +31,78 @@ pub enum OrderType {
     ExchangeIoc,
 }
 
+impl Serialize for OrderType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            OrderType::Limit => serializer.serialize_unit_variant("OrderType", 0, "LIMIT"),
+            OrderType::ExchangeLimit => {
+                serializer.serialize_unit_variant("OrderType", 1, "EXCHANGE LIMIT")
+            }
+            OrderType::Market => serializer.serialize_unit_variant("OrderType", 2, "MARKET"),
+            OrderType::ExchangeMarket => {
+                serializer.serialize_unit_variant("OrderType", 3, "EXCHANGE MARKET")
+            }
+            OrderType::Stop => serializer.serialize_unit_variant("OrderType", 4, "STOP"),
+            OrderType::ExchangeStop => {
+                serializer.serialize_unit_variant("OrderType", 5, "EXCHANGE STOP")
+            }
+            OrderType::StopLimit => serializer.serialize_unit_variant("OrderType", 6, "STOP LIMIT"),
+            OrderType::ExchangeStopLimit => {
+                serializer.serialize_unit_variant("OrderType", 7, "EXCHANGE STOP LIMIT")
+            }
+            OrderType::TrailingStop => {
+                serializer.serialize_unit_variant("OrderType", 8, "TRAILING STOP")
+            }
+            OrderType::ExchangeTrailingStop => {
+                serializer.serialize_unit_variant("OrderType", 9, "EXCHANGE TRAILING STOP")
+            }
+            OrderType::Fok => serializer.serialize_unit_variant("OrderType", 10, "FOK"),
+            OrderType::ExchangeFok => {
+                serializer.serialize_unit_variant("OrderType", 11, "EXCHANGE FOK")
+            }
+            OrderType::Ioc => serializer.serialize_unit_variant("OrderType", 12, "IOC"),
+            OrderType::ExchangeIoc => {
+                serializer.serialize_unit_variant("OrderType", 13, "EXCHANGE IOC")
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OrderType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?.to_uppercase();
+        let state = match s.as_str() {
+            "LIMIT" => OrderType::Limit,
+            "EXCHANGE LIMIT" => OrderType::ExchangeLimit,
+            "MARKET" => OrderType::Market,
+            "EXCHANGE MARKET" => OrderType::ExchangeMarket,
+            "STOP" => OrderType::Stop,
+            "EXCHANGE STOP" => OrderType::ExchangeStop,
+            "STOP LIMIT" => OrderType::StopLimit,
+            "EXCHANGE STOP LIMIT" => OrderType::ExchangeStopLimit,
+            "TRAILING STOP" => OrderType::TrailingStop,
+            "EXCHANGE TRAILING STOP" => OrderType::ExchangeTrailingStop,
+            "FOK" => OrderType::Fok,
+            "EXCHANGE FOK" => OrderType::ExchangeFok,
+            "IOC" => OrderType::Ioc,
+            "EXCHANGE IOC" => OrderType::ExchangeIoc,
+            other => {
+                return Err(serde::de::Error::custom(format!(
+                    "Invalid state '{}'",
+                    other
+                )));
+            }
+        };
+        Ok(state)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Order {
     pub id: u64,
@@ -43,7 +114,7 @@ pub struct Order {
     pub amount: f64,
     pub amount_orig: f64,
     pub order_type: OrderType,
-    pub type_prev: OrderType,
+    pub type_prev: Option<OrderType>,
     pub mts_tif: Option<u64>,
     pub flags: Option<u64>,
     pub status: String,
@@ -55,6 +126,7 @@ pub struct Order {
     pub hidden: bool,
     pub placed_id: Option<u64>,
     pub routing: String,
+    pub meta: Option<serde_json::Value>,
 }
 
 impl<'de> Deserialize<'de> for Order {
@@ -78,7 +150,7 @@ pub struct OrderRaw(
     f64,
     f64,
     OrderType,
-    OrderType,
+    Option<OrderType>,
     Option<u64>,
     PlaceHolder,
     Option<u64>,
@@ -98,6 +170,9 @@ pub struct OrderRaw(
     PlaceHolder,
     PlaceHolder,
     String,
+    PlaceHolder,
+    PlaceHolder,
+    Option<serde_json::Value>,
 );
 
 impl From<OrderRaw> for Order {
@@ -132,6 +207,9 @@ impl From<OrderRaw> for Order {
             _,
             _,
             routing,
+            _,
+            _,
+            meta,
         ) = value;
 
         Self {
@@ -156,6 +234,7 @@ impl From<OrderRaw> for Order {
             hidden: hidden == 1,
             placed_id,
             routing,
+            meta,
         }
     }
 }

--- a/src/api/authenticated/orders/types.rs
+++ b/src/api/authenticated/orders/types.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use crate::api::common::PlaceHolder;
 
@@ -13,94 +13,36 @@ pub enum OrderFlag {
     NoVarRates = 524288,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OrderType {
+    #[serde(rename = "LIMIT")]
     Limit,
+    #[serde(rename = "EXCHANGE LIMIT")]
     ExchangeLimit,
+    #[serde(rename = "MARKET")]
     Market,
+    #[serde(rename = "EXCHANGE MARKET")]
     ExchangeMarket,
+    #[serde(rename = "STOP")]
     Stop,
+    #[serde(rename = "EXCHANGE STOP")]
     ExchangeStop,
+    #[serde(rename = "STOP LIMIT")]
     StopLimit,
+    #[serde(rename = "EXCHANGE STOP LIMIT")]
     ExchangeStopLimit,
+    #[serde(rename = "TRAILING STOP")]
     TrailingStop,
+    #[serde(rename = "EXCHANGE TRAILING STOP")]
     ExchangeTrailingStop,
+    #[serde(rename = "FOK")]
     Fok,
+    #[serde(rename = "EXCHANGE FOK")]
     ExchangeFok,
+    #[serde(rename = "IOC")]
     Ioc,
+    #[serde(rename = "EXCHANGE IOC")]
     ExchangeIoc,
-}
-
-impl Serialize for OrderType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match *self {
-            OrderType::Limit => serializer.serialize_unit_variant("OrderType", 0, "LIMIT"),
-            OrderType::ExchangeLimit => {
-                serializer.serialize_unit_variant("OrderType", 1, "EXCHANGE LIMIT")
-            }
-            OrderType::Market => serializer.serialize_unit_variant("OrderType", 2, "MARKET"),
-            OrderType::ExchangeMarket => {
-                serializer.serialize_unit_variant("OrderType", 3, "EXCHANGE MARKET")
-            }
-            OrderType::Stop => serializer.serialize_unit_variant("OrderType", 4, "STOP"),
-            OrderType::ExchangeStop => {
-                serializer.serialize_unit_variant("OrderType", 5, "EXCHANGE STOP")
-            }
-            OrderType::StopLimit => serializer.serialize_unit_variant("OrderType", 6, "STOP LIMIT"),
-            OrderType::ExchangeStopLimit => {
-                serializer.serialize_unit_variant("OrderType", 7, "EXCHANGE STOP LIMIT")
-            }
-            OrderType::TrailingStop => {
-                serializer.serialize_unit_variant("OrderType", 8, "TRAILING STOP")
-            }
-            OrderType::ExchangeTrailingStop => {
-                serializer.serialize_unit_variant("OrderType", 9, "EXCHANGE TRAILING STOP")
-            }
-            OrderType::Fok => serializer.serialize_unit_variant("OrderType", 10, "FOK"),
-            OrderType::ExchangeFok => {
-                serializer.serialize_unit_variant("OrderType", 11, "EXCHANGE FOK")
-            }
-            OrderType::Ioc => serializer.serialize_unit_variant("OrderType", 12, "IOC"),
-            OrderType::ExchangeIoc => {
-                serializer.serialize_unit_variant("OrderType", 13, "EXCHANGE IOC")
-            }
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for OrderType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?.to_uppercase();
-        let state = match s.as_str() {
-            "LIMIT" => OrderType::Limit,
-            "EXCHANGE LIMIT" => OrderType::ExchangeLimit,
-            "MARKET" => OrderType::Market,
-            "EXCHANGE MARKET" => OrderType::ExchangeMarket,
-            "STOP" => OrderType::Stop,
-            "EXCHANGE STOP" => OrderType::ExchangeStop,
-            "STOP LIMIT" => OrderType::StopLimit,
-            "EXCHANGE STOP LIMIT" => OrderType::ExchangeStopLimit,
-            "TRAILING STOP" => OrderType::TrailingStop,
-            "EXCHANGE TRAILING STOP" => OrderType::ExchangeTrailingStop,
-            "FOK" => OrderType::Fok,
-            "EXCHANGE FOK" => OrderType::ExchangeFok,
-            "IOC" => OrderType::Ioc,
-            "EXCHANGE IOC" => OrderType::ExchangeIoc,
-            other => {
-                return Err(serde::de::Error::custom(format!(
-                    "Invalid state '{}'",
-                    other
-                )));
-            }
-        };
-        Ok(state)
-    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
1. In fact avilable order types are not the `SCREAMING_SNAKE_CASE` but uppercase where words separated by spaces. So long as serde leave us without some macro for this case we need to use a manual implementation of serialize and deserialize.

2. Seems `Order` was expanded a bit since the last implementation, now it is closer to documentation again.

p.s. thanks for the great api implementation!