### PR TITLE
chore(auth/orders_history): impl orders history endpoint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
-    "name": "bitfinex-api",
+    "name": "bitfinex-api-pr",
     // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
     "runArgs": [
-        "--name=bitfinex-api"
+        "--name=bitfinex-api-pr"
     ],
     "customizations": {
         "vscode": {

--- a/examples/authenticated_endpoints.rs
+++ b/examples/authenticated_endpoints.rs
@@ -142,7 +142,7 @@ async fn main() {
     // println!("{r:#?}");
 
     let endpoint = OrdersHistory::builder().limit(5).build().unwrap();
-    ignore(endpoint).query_async(&client).await;
-    // let res: Result<OrdersHistoryResp, ApiError<_>> = endpoint.query_async(&self.client).await;
+    ignore(endpoint).query_async(&client).await.unwrap();
+    // let r: OrdersHistoryResp = endpoint.query_async(&client).await.unwrap();
     // println!("{r:#?}");
 }

--- a/examples/authenticated_endpoints.rs
+++ b/examples/authenticated_endpoints.rs
@@ -15,6 +15,7 @@ use bitfinex_api::{
             orders::{
                 cancel_order::{CancelOrder, CancelOrderResp},
                 cancel_orders::{CancelOrders, CancelOrdersResp, CancelOrdersType},
+                orders_history::{OrdersHistory, OrdersHistoryResp},
                 retrieve_orders::{RetrieveOrders, RetrieveOrdersResp},
                 retrieve_orders_by_symbol::{RetrieveOrdersBySymbol, RetrieveOrdersBySymbolResp},
                 submit_order::{SubmitOrder, SubmitOrderResp},
@@ -138,5 +139,10 @@ async fn main() {
     let endpoint = Trades::builder().limit(5).build().unwrap();
     ignore(endpoint).query_async(&client).await.unwrap();
     // let r: TradesResp = endpoint.query_async(&client).await.unwrap();
+    // println!("{r:#?}");
+
+    let endpoint = OrdersHistory::builder().limit(5).build().unwrap();
+    ignore(endpoint).query_async(&client).await;
+    // let res: Result<OrdersHistoryResp, ApiError<_>> = endpoint.query_async(&self.client).await;
     // println!("{r:#?}");
 }

--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,9 @@ Feel free to dig in the individual endpoints source code (in the [`api/public`](
     - Endpoint `CancelOrders`
     - Return `CancelOrdersResp`
 - :black_square_button: [Order Multi-OP](https://docs.bitfinex.com/reference/rest-auth-order-multi)
-- :black_square_button: [Orders History](https://docs.bitfinex.com/reference/rest-auth-orders-history)
+- :white_check_mark: [Orders History](https://docs.bitfinex.com/reference/rest-auth-orders-history)
+    - Endpoint `OrdersHistory`
+    - Return `OrdersHistoryResp`
 - :black_square_button: [Orders History (by symbol)](https://docs.bitfinex.com/reference/rest-auth-orders-history-by-symbol)
 - :black_square_button: [Order Trades](https://docs.bitfinex.com/reference/rest-auth-order-trades)
 - :white_check_mark: [Trades](https://docs.bitfinex.com/reference/rest-auth-trades)

--- a/src/api/authenticated/orders/mod.rs
+++ b/src/api/authenticated/orders/mod.rs
@@ -3,4 +3,5 @@ pub mod cancel_orders;
 pub mod retrieve_orders;
 pub mod retrieve_orders_by_symbol;
 pub mod submit_order;
+pub mod orders_history;
 pub mod types;

--- a/src/api/authenticated/orders/orders_history/mod.rs
+++ b/src/api/authenticated/orders/orders_history/mod.rs
@@ -1,0 +1,102 @@
+use derive_builder::Builder;
+use http::Method;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::api::endpoint::Endpoint;
+
+use super::types::Order;
+use super::types::OrderRaw;
+
+/// https://docs.bitfinex.com/reference/rest-auth-orders-history
+#[derive(Debug, Clone, Builder)]
+#[builder(setter(strip_option))]
+pub struct OrdersHistory {
+    #[builder(default)]
+    start: Option<u64>,
+    #[builder(default)]
+    end: Option<u64>,
+    #[builder(default)]
+    limit: Option<u64>,
+    #[builder(default)]
+    id: Option<u64>,
+}
+
+impl OrdersHistory {
+    pub fn builder() -> OrdersHistoryBuilder {
+        OrdersHistoryBuilder::default()
+    }
+
+    fn json_body(&self) -> String {
+        #[serde_as]
+        #[derive(Debug, Serialize)]
+        pub struct JsonParams {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+            start: Option<u64>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+            end: Option<u64>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+            limit: Option<u64>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            id: Option<u64>,
+        }
+
+        let p = JsonParams {
+            start: self.start,
+            end: self.end,
+            limit: self.limit,
+            id: self.id,
+        };
+
+        serde_json::to_string(&p).unwrap()
+    }
+}
+
+impl Endpoint for OrdersHistory {
+    fn method(&self) -> Method {
+        Method::POST
+    }
+
+    fn endpoint(&self) -> String {
+        String::from("v2/auth/r/orders/hist")
+    }
+
+    fn is_authenticated(&self) -> bool {
+        true
+    }
+
+    fn body(&self) -> Option<(&'static str, Vec<u8>)> {
+        Some(("application/json", self.json_body().into_bytes()))
+    }
+}
+
+#[derive(Debug)]
+pub struct OrdersHistoryResp {
+    pub orders: Vec<Order>,
+}
+
+impl<'de> Deserialize<'de> for OrdersHistoryResp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Debug, Deserialize)]
+        struct OrdersHistoryRawResp(Vec<OrderRaw>);
+
+        impl From<OrdersHistoryRawResp> for OrdersHistoryResp {
+            fn from(value: OrdersHistoryRawResp) -> Self {
+                let OrdersHistoryRawResp(orders) = value;
+
+                Self {
+                    orders: orders.into_iter().map(|order| order.into()).collect(),
+                }
+            }
+        }
+
+        let raw = OrdersHistoryRawResp::deserialize(deserializer)?;
+        Ok(raw.into())
+    }
+}

--- a/src/api/authenticated/orders/orders_history/mod.rs
+++ b/src/api/authenticated/orders/orders_history/mod.rs
@@ -19,7 +19,7 @@ pub struct OrdersHistory {
     #[builder(default)]
     limit: Option<u64>,
     #[builder(default)]
-    id: Option<u64>,
+    id: Option<Vec<u64>>,
 }
 
 impl OrdersHistory {
@@ -30,25 +30,22 @@ impl OrdersHistory {
     fn json_body(&self) -> String {
         #[serde_as]
         #[derive(Debug, Serialize)]
-        pub struct JsonParams {
+        pub struct JsonParams<'a> {
             #[serde(skip_serializing_if = "Option::is_none")]
-            #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
             start: Option<u64>,
             #[serde(skip_serializing_if = "Option::is_none")]
-            #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
             end: Option<u64>,
             #[serde(skip_serializing_if = "Option::is_none")]
-            #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
             limit: Option<u64>,
             #[serde(skip_serializing_if = "Option::is_none")]
-            id: Option<u64>,
+            id: Option<&'a [u64]>,
         }
 
         let p = JsonParams {
             start: self.start,
             end: self.end,
             limit: self.limit,
-            id: self.id,
+            id: self.id.as_ref().map(|ids| &ids[..]),
         };
 
         serde_json::to_string(&p).unwrap()


### PR DESCRIPTION
Hi @xenoliss, here another tiny change, please review as you can

Note:
in example I used an explicit type annotation (as in my local experiments). 
`let res: Result<OrdersHistoryResp, ApiError<_>> = endpoint.query_async(&self.client).await;`

When I first started with endpoints I spent some time to find which type the endpoint must return - may be someone else find this line in example helpful too